### PR TITLE
Fix #993 by setting company backend in java/+meghanada.el

### DIFF
--- a/modules/lang/java/+meghanada.el
+++ b/modules/lang/java/+meghanada.el
@@ -14,6 +14,8 @@
     :definition #'meghanada-jump-declaration
     :references #'meghanada-reference)
 
+  (set-company-backend! 'java-mode '(company-meghanada :separate company-dabbrev-code))
+
   (map! :localleader
         :map java-mode-map
         (:prefix ("r" . "refactor")


### PR DESCRIPTION
Currently, if you have (java +meghanada) in your config and open a .java file, the autocompletion Meghanada provides will not work. Running company-diag gives company-backends: (company-capf company-yasnippet). 
Turning meghanada-mode on and off again is a workaround; company-diag then gives company-backends: ((company-meghanada :separate company-dabbrev-code)).
This commit makes it so that set-company-backend! is done automatically when Meghanada is loaded, as is done for robe in https://github.com/hlissner/doom-emacs/blob/develop/modules/lang/ruby/config.el.